### PR TITLE
Fix text overlap on mobile by centering text in single flow container

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,22 +14,18 @@
 </head>
 <body>
 
-    <div id = "test" style="position:absolute; z-index: 1000; color: #f5f5f5; top: 45%;
-    text-align: center; width: 100%; left: 0px; font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, monospace;">
+    <div id = "test" style="position:absolute; z-index: 1000; color: #f5f5f5; top: 50%;
+    transform: translateY(-50%); text-align: center; width: 100%; left: 0px; padding: 0 16px;
+    box-sizing: border-box; font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, monospace;">
       <p>
           Hey! I'm Snehith<br>
           I like building and understanding tech from the ground up.
       </p>
-    </div> 
-
-
-    <div id = "test1" style="position:absolute; z-index: 1000; color: #f5f5f5; top: 55%;
-    text-align: center; width: 100%; left: 0px; font-family: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, monospace;">
-        <p>
-          <a href="whoami.html" style="color: #f5f5f5;">
-            Click here to see what I'm working on<br>
-          </a>
-        </p>
+      <p>
+        <a href="whoami.html" style="color: #f5f5f5;">
+          Click here to see what I'm working on
+        </a>
+      </p>
     </div>
 
     <div style="position:absolute; z-index: 1000; color: #f5f5f5; bottom: 50px;


### PR DESCRIPTION
The intro text and 'working on' link were absolutely positioned at fixed
top: 45% and top: 55%. On mobile the intro paragraph wraps to more lines and
overflowed into the link block, causing overlap. Combining them into one
vertically-centered container lets the text flow naturally without overlap.