### PR TITLE
Add "Since the Big Bang" universe timeline to Tinkering

### DIFF
--- a/whoami.html
+++ b/whoami.html
@@ -722,6 +722,20 @@
 
       <div class="log-entry">
         <div class="log-meta">
+          <span class="log-date">Jul 2026</span>
+          <span class="log-type">viz</span>
+        </div>
+        <div class="log-body">
+          <h3 class="log-title">Since the Big Bang &mdash; the whole universe as a scrollable grid</h3>
+          <p class="log-desc">An interactive timeline that lays out all 13.8 billion years as a grid of blocks &mdash; each square a slice of deep time, from the Big Bang down to this exact second. Scroll to fly through cosmic history at a constant pace no matter how far you zoom; blocks are colour-coded across six epochs &mdash; Cosmos, Earth &amp; planets, Life &amp; evolution, Human origins, Civilization, Science &amp; tech &mdash; and a floating legend lets you filter to just the ones you want. Hover any milestone for a note, and watch the current moment tick live at the very bottom. The whole thing is one self-contained HTML file.</p>
+          <div class="p-links">
+            <a href="universe.html" target="_blank" rel="noopener">launch</a>
+          </div>
+        </div>
+      </div>
+
+      <div class="log-entry">
+        <div class="log-meta">
           <span class="log-date">Jun 2026</span>
           <span class="log-type">tool</span>
         </div>


### PR DESCRIPTION
## What

Adds the **Since the Big Bang** universe timeline as the newest entry in the Tinkering section of `whoami.html`.

It's an interactive timeline that lays out all 13.8 billion years as a scrollable grid of blocks — from the Big Bang to this exact second. Constant-speed virtual scroll at any zoom, six colour-coded epochs (Cosmos, Earth & planets, Life & evolution, Human origins, Civilization, Science & tech) with a filterable floating legend, hover-able milestone notes, and a live "now" clock at the bottom. One self-contained HTML file.

## Scope

- Single change: a 14-line `log-entry` in the Tinkering feed linking to `universe.html` (opens in a new tab).
- Reuses existing `log-entry` / `p-links` styles — no new CSS.
- `universe.html` itself is already on `main`; this PR just surfaces it on the whoami page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)